### PR TITLE
Remove PhantomData to simplify BlockImport

### DIFF
--- a/src/block_processor.rs
+++ b/src/block_processor.rs
@@ -91,12 +91,8 @@ pub fn setup_block_processor(
         )
         .map_err(|e| format!("{}", e))?;
         let mut grandpa_verifier = GrandpaVerifier::new(client.clone());
-        let mut block_import_wrapper: BlockImportWrapper<
-            _,
-            Block,
-            Backend<LightStorage<Block>, BlakeTwo256>,
-            _,
-        > = BlockImportWrapper::new(grandpa_block_import.clone(), client.clone());
+        let mut block_import_wrapper: BlockImportWrapper<_, _> =
+            BlockImportWrapper::new(grandpa_block_import.clone(), client.clone());
         import_single_block(
             &mut block_import_wrapper,
             BlockOrigin::NetworkBroadcast,


### PR DESCRIPTION
Removes PhantomData to make it clearer what the intention of this code is doing. Might not be an issue for all but the use of PhantomData made me think this type was doing something with that data and I was a bit confused by it.

This simplifies the wrapper a bit and makes the intent a bit clearer.